### PR TITLE
Fixed Delete operation not working on downloading screen.

### DIFF
--- a/Netflix/ViewControllers/NFDownloadsVC.swift
+++ b/Netflix/ViewControllers/NFDownloadsVC.swift
@@ -76,8 +76,7 @@ extension NFDownloadsVC: UITableViewDataSource, UITableViewDelegate {
     func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
         
         if editingStyle == UITableViewCell.EditingStyle.delete {
-            let model = viewModel.movieList[indexPath.row]
-            viewModel.delete(using: model.id)
+            viewModel.delete(at: indexPath.row)
             tableView.deleteRows(at: [indexPath], with: .fade)
         }
     }

--- a/Netflix/ViewModels/NFDownloadVM.swift
+++ b/Netflix/ViewModels/NFDownloadVM.swift
@@ -22,8 +22,9 @@ final class NFDownloadVM {
         movieList.append(contentsOf: movies)
     }
     
-    func delete(using id: Int) {
-        movieList.remove(at: id)
+    func delete(at index: Int) {
+        let id = movieList[index].id
+        movieList.remove(at: index)
         repository.delete(by: Int64(id))
     }
 }


### PR DESCRIPTION
Problem: Movieitem id is used as an index to retrieve movie from array list.

Solution: Replaced id with index which we get from UICollectionView method to get movie item.